### PR TITLE
fix(display): emoji 变体选择符强制宽度2,修复编辑模式重叠

### DIFF
--- a/internal/display/bufwindow_md.go
+++ b/internal/display/bufwindow_md.go
@@ -613,10 +613,10 @@ func (w *BufWindow) renderSegmentNative(
 				totalwidth += ts
 			default:
 				width = runewidth.RuneWidth(r)
-				// Emoji variation selector (U+FE00-U+FE0F) makes the base symbol render as a wide emoji
-				// (e.g. U+26A0 U+FE0F -> ⚠️). Force width 2 so it does not overlap the next character.
+				// Only U+FE0F (VS16, emoji style) forces the base symbol to render as a 2-column emoji.
+				// U+FE0E (VS15, text style) and other variation selectors keep the base width.
 				for _, c := range combc {
-					if c >= 0xFE00 && c <= 0xFE0F {
+					if c == 0xFE0F {
 						width = 2
 						break
 					}

--- a/internal/display/bufwindow_md.go
+++ b/internal/display/bufwindow_md.go
@@ -613,6 +613,14 @@ func (w *BufWindow) renderSegmentNative(
 				totalwidth += ts
 			default:
 				width = runewidth.RuneWidth(r)
+				// Emoji variation selector (U+FE00-U+FE0F) makes the base symbol render as a wide emoji
+				// (e.g. U+26A0 U+FE0F -> ⚠️). Force width 2 so it does not overlap the next character.
+				for _, c := range combc {
+					if c >= 0xFE00 && c <= 0xFE0F {
+						width = 2
+						break
+					}
+				}
 				totalwidth += width
 			}
 


### PR DESCRIPTION
## 问题
编辑模式下 ⚠️ 等「基础符号 + U+FE0F 变体选择符」emoji 与后续字符重叠或显示不全(预览/渲染模式正常)。

## 根因(实测 + 源码)
1. **go-runewidth v0.0.16 缺陷**:变体选择符 U+FE00-FE0F 被错误归入 doublewidth 表(`runewidth_table.go` L124),`RuneWidth(U+FE0E)=RuneWidth(U+FE0F)=2`,本应 0 宽(Unicode Mn 类别)。社区已确认并修复:mattn/go-runewidth#76 + PR#90(merged),新版本已返回 0。
2. **micro 编辑模式宽度模型**:渲染用 `RuneWidth(基础符号)` 计宽(⚠=1),组合符一律当零宽附加。但 VS16 会改变基础符号宽度 → ⚠️ 在终端按 2 列 emoji 绘制,编辑器却算 1 列,后续字符重叠/消失。
3. **升级 go-runewidth 不能解决**:即使 VS 宽度修成 0,micro 仍只对基础符号计宽(1 列),终端仍画 2 列。实测 v0.0.27 全配置下 `StringWidth("⚠️")` 仍为 1。此修复必须发生在 micro 渲染层。

实测(Windows 11 / microNeo 1.0.12 / go-runewidth v0.0.16):

| 组合 | RuneWidth(基础) | 终端实际 | 正确宽度 |
|------|:---:|:---:|:---:|
| ⚠️ (26A0+FE0F, emoji 样式) | 1 | 2 列 | 2 |
| ⚠︎ (26A0+FE0E, 文本样式) | 1 | 1 列 | 1 |
| ©️ (00A9+FE0F, emoji 样式) | 1 | 2 列 | 2 |
| ♥️ (2665+FE0F) | 2 | 2 列 | 2 |

## 修复(临时方案)
`combc` 中**仅检测 U+FE0F(VS16,语义为强制 emoji 样式)**时强制宽度 2,与终端绘制对齐。

- **不处理 U+FE0E(VS15,强制文本样式)**:仍按基础符号宽度,避免误伤文本样式变体。
- **不处理 U+FE00-U+FE0D(CJK 兼容表意文字变体)**:与 emoji 宽度无关。

## 本修复的定位与理想方案
⚠️ **这是一个临时(minimal)修补**,精准覆盖「基础符号 + U+FE0F」这一最常见的 emoji 重叠场景,不代表对 emoji 宽度问题的完整解决。

**局限**:
- 只识别 U+FE0F 一个变宽开关,未覆盖 ZWJ 序列、肤色修饰符等其它 emoji 宽度场景。
- 宽度是对终端的启发式对齐(假设 VS16 emoji 渲染为 2 列),非标准宽度判定。

**最完善的方案**:
- microNeo 渲染层应引入 **grapheme-cluster 感知的宽度计算**(基于 UTS#29 分词 + UTS#51 emoji 呈现规则),对完整 emoji 序列统一计算显示宽度,而非「基础符号 + 组合符」拆开计宽。这需要重写 `internal/display` 与 `internal/util` 的宽度逻辑(如基于 uniseg 的宽度引擎)。
- 配套:升级 go-runewidth v0.0.16 → 最新(修复 VS 自身宽度、Indic 组合标记、旗标等底层问题)。
- 鉴于改造影响全局布局、风险高,本 PR 先以最小补丁解决当前最痛的 bug,理想方案建议作为后续演进方向。

Fixes #12